### PR TITLE
fix: Home Now 상단 포스터 첫번째 슬라이드에서 왼쪽 이동, 마지막 슬라이드에서 오른쪽 이동 방지

### DIFF
--- a/src/app/(has-navigation)/home/now/page.tsx
+++ b/src/app/(has-navigation)/home/now/page.tsx
@@ -68,7 +68,7 @@ export default function NowPage() {
   return (
     <div className="flex flex-col items-center">
       {/* 슬라이드 섹션 및 ExhibitionCarousel을 동일한 부모 컨테이너에 넣음 */}
-      <div className="relative mx-auto w-[100%] max-w-[1200px]">
+      <div className="relative mx-auto w-[100%]">
         {/* 슬라이드 섹션 */}
         <div className="relative mb-[30px] flex h-[642px] items-center justify-center">
           {/* 상태바 */}
@@ -86,8 +86,11 @@ export default function NowPage() {
           <Swiper
             effect="fade"
             onSlideChange={(swiper) => {
+              // 슬라이더의 현재 인덱스 상태 업데이트
               setCurrentSlide(swiper.activeIndex)
             }}
+            allowSlidePrev={currentSlide !== 0} // 첫 번째 슬라이드에서 이전으로 넘어가지 않도록 설정
+            allowSlideNext={currentSlide !== slides.length - 1} // 마지막 슬라이드에서 다음으로 넘어가지 않도록 설정
             className="h-full w-full"
           >
             {slides.map((slide, index) => (


### PR DESCRIPTION
- 홈 Now 상단 포스터 좌우 슬라이드에서 첫번째 화면에서 왼쪽 이동 방지, 마지막 화면에서 우측 이동 방지 (기존에는 이동이 작동해서 빈 여백이 나타나는 바운싱 있었음)