### PR TITLE
feat: Home EXHIBITION 헤더 고정 UI 적용

### DIFF
--- a/src/actions/getExhibitions.ts
+++ b/src/actions/getExhibitions.ts
@@ -14,6 +14,7 @@ export async function getOngoingExhibitions() {
         id: 'asc',
       },
     })
+    console.log(popularExhibitions)
     return { data: popularExhibitions }
   } catch (error) {
     console.error('Error fetching current exhibitions:', error)
@@ -35,6 +36,7 @@ export async function getUpcomingExhibitions() {
         id: 'desc',
       },
     })
+    console.log(upcomingExhibitions)
     return { data: upcomingExhibitions }
   } catch (error) {
     console.error('Error fetching current exhibitions:', error)

--- a/src/app/(has-navigation)/home/exhibition/page.tsx
+++ b/src/app/(has-navigation)/home/exhibition/page.tsx
@@ -1,10 +1,19 @@
+// pages/ExhibitionPage.tsx
 'use client'
 
 import { useEffect, useState } from 'react'
 
 import Image from 'next/image'
+import Link from 'next/link'
 
 import { getAllExhibitions } from '@/actions/getExhibitions'
+import { LAYOUT } from '@/constants/layout'
+import { PAGE_ROUTES } from '@/constants/routes'
+import { cn } from '@/utils/utils'
+
+// pages/ExhibitionPage.tsx
+
+// pages/ExhibitionPage.tsx
 
 export default function ExhibitionPage() {
   const [exhibitions, setExhibitions] = useState<any[]>([])
@@ -13,7 +22,7 @@ export default function ExhibitionPage() {
     async function fetchData() {
       try {
         const result = await getAllExhibitions()
-        setExhibitions(result.data.flat() as any[]) // 데이터를 플랫하게 해서 하나의 배열로 만듦
+        setExhibitions(result.data.flat() as any[])
       } catch (error) {
         console.error('Error fetching exhibitions:', error)
       }
@@ -23,7 +32,39 @@ export default function ExhibitionPage() {
 
   return (
     <>
-      <div className="min-h-[1000px] bg-slate-500 pt-[60px]">
+      {/* 독립된 고정 헤더, NowPage와 완전히 동일한 스타일 적용 */}
+      <header
+        className={cn(
+          `h-[${LAYOUT.HEADER.HEIGHT}]`,
+          'fixed top-0 z-50 flex w-full max-w-screen-sm items-center justify-center',
+          'transition-colors duration-300 ease-in-out',
+          'bg-grayscale_white', // 고정된 배경색을 흰색으로 설정
+        )}
+      >
+        <nav className="flex w-full items-center p-[12px]">
+          <ul className="flex gap-5">
+            <li
+              className={cn(
+                'mobile-extra-large font-bold uppercase text-gray-400 opacity-50',
+                'text-center',
+              )}
+            >
+              <Link href={PAGE_ROUTES.NOW}>Now</Link>
+            </li>
+            <li
+              className={cn(
+                'mobile-extra-large font-bold uppercase text-black',
+                'text-center',
+              )}
+            >
+              <Link href={PAGE_ROUTES.EXHIBITION}>Exhibition</Link>
+            </li>
+          </ul>
+        </nav>
+      </header>
+
+      {/* 전시 콘텐츠 */}
+      <main className="min-h-[1000px] bg-slate-500 pt-[80px]">
         <div className="mb-8 h-px bg-slate-500"></div>
         <div className="grid grid-cols-2 gap-4 px-4 pb-5">
           {exhibitions.length === 0 ?
@@ -42,7 +83,6 @@ export default function ExhibitionPage() {
                   className="rounded"
                 />
               </div>
-              {/* 전시 상태 로고 */}
               <div
                 className="justify-left my-1 flex"
                 style={{ marginTop: '12px', marginBottom: '9px' }}
@@ -77,13 +117,15 @@ export default function ExhibitionPage() {
               </div>
               <h3 className="mb-1 text-lg font-semibold">{exhibition.title}</h3>
               <p className="text-sm text-gray-600">
-                {`${new Date(exhibition.startDate).toLocaleDateString()} ~ ${new Date(exhibition.endDate).toLocaleDateString()}`}
+                {`${new Date(exhibition.startDate).toLocaleDateString()} ~ ${new Date(
+                  exhibition.endDate,
+                ).toLocaleDateString()}`}
               </p>
               <p className="text-sm text-gray-600">{exhibition.place}</p>
             </div>
           ))}
         </div>
-      </div>
+      </main>
     </>
   )
 }

--- a/src/app/(has-navigation)/home/now/page.tsx
+++ b/src/app/(has-navigation)/home/now/page.tsx
@@ -26,7 +26,7 @@ interface Slide {
 
 export default function NowPage() {
   const [currentSlide, setCurrentSlide] = useState<number>(0)
-  const [exhibitionsData, setExhibitionsData] = useState<any[]>([])
+  const [exhibitionsData, setExhibitionsData] = useState<unknown[][]>([])
 
   const slides: Slide[] = [
     {
@@ -48,15 +48,13 @@ export default function NowPage() {
   useEffect(() => {
     async function fetchData() {
       try {
-        // 진행 중인 전시 데이터를 가져오기
         const ongoingResponse = await getOngoingExhibitions()
         const ongoingExhibitions = ongoingResponse.data
 
-        // 곧 있을 전시 데이터를 가져오기
         const upcomingResponse = await getUpcomingExhibitions()
         const upcomingExhibitions = upcomingResponse.data
 
-        // 두 개의 전시 데이터를 각각 배열로 넣음
+        // 두 개의 전시 데이터를 각각 배열에 넣음
         setExhibitionsData([ongoingExhibitions, upcomingExhibitions])
       } catch (error) {
         console.error('Error fetching exhibitions:', error)
@@ -67,11 +65,8 @@ export default function NowPage() {
 
   return (
     <div className="flex flex-col items-center">
-      {/* 슬라이드 섹션 및 ExhibitionCarousel을 동일한 부모 컨테이너에 넣음 */}
       <div className="relative mx-auto w-[100%]">
-        {/* 슬라이드 섹션 */}
         <div className="relative mb-[30px] flex h-[642px] items-center justify-center">
-          {/* 상태바 */}
           <div className="absolute bottom-[75px] left-1/2 z-50 h-[3px] w-[300px] -translate-x-1/2 transform rounded-full bg-gray-400">
             <div
               className="h-full rounded-full bg-white transition-all duration-500 ease-in-out"
@@ -82,15 +77,13 @@ export default function NowPage() {
               }}
             ></div>
           </div>
-          {/* Swiper 슬라이더 */}
           <Swiper
             effect="fade"
             onSlideChange={(swiper) => {
-              // 슬라이더의 현재 인덱스 상태 업데이트
               setCurrentSlide(swiper.activeIndex)
             }}
-            allowSlidePrev={currentSlide !== 0} // 첫 번째 슬라이드에서 이전으로 넘어가지 않도록 설정
-            allowSlideNext={currentSlide !== slides.length - 1} // 마지막 슬라이드에서 다음으로 넘어가지 않도록 설정
+            allowSlidePrev={currentSlide !== 0}
+            allowSlideNext={currentSlide !== slides.length - 1}
             className="h-full w-full"
           >
             {slides.map((slide, index) => (
@@ -127,9 +120,11 @@ export default function NowPage() {
           </ExhibitionCarousel>
         )}
         {/* 다가오는 전시 Carousel */}
-        <ExhibitionCarousel exhibitions={exhibitionsData[1]}>
-          다가오는 전시
-        </ExhibitionCarousel>
+        {exhibitionsData[1] && (
+          <ExhibitionCarousel exhibitions={exhibitionsData[1]}>
+            다가오는 전시
+          </ExhibitionCarousel>
+        )}
       </div>
     </div>
   )

--- a/src/components/@Layout/HomeLayout/HomeLayout.tsx
+++ b/src/components/@Layout/HomeLayout/HomeLayout.tsx
@@ -1,3 +1,4 @@
+// HomeLayout.tsx
 'use client'
 
 import { ReactNode, useCallback, useEffect, useState } from 'react'
@@ -8,22 +9,30 @@ import { cn } from '@/utils/utils'
 import HomeFooter from './components/HomeFooter'
 import HomeHeader from './components/HomeHeader'
 
+// HomeLayout.tsx
+
+// HomeLayout.tsx
+
+// HomeLayout.tsx
+
 interface HomeLayoutProps {
   header?: ReactNode | ((props: { isScroll: boolean }) => ReactNode)
   footer?: ReactNode
   content?: ReactNode
+  fixedScroll?: boolean // New prop to enforce scroll style statically
 }
 
 const HomeLayout = ({
   header = ({ isScroll }) => <HomeHeader isScroll={isScroll} />,
   footer = <HomeFooter />,
   content,
+  fixedScroll = false, // Default behavior is to not fix the scroll style
 }: HomeLayoutProps) => {
-  const [isScroll, setIsScroll] = useState(false)
+  const [isScroll, setIsScroll] = useState(fixedScroll)
 
   const handleScroll = useCallback(() => {
-    setIsScroll(window.scrollY > 60)
-  }, [])
+    if (!fixedScroll) setIsScroll(window.scrollY > 60)
+  }, [fixedScroll])
 
   useEffect(() => {
     window.addEventListener('scroll', handleScroll)
@@ -50,7 +59,7 @@ const HomeLayout = ({
       >
         {typeof header === 'function' ? header({ isScroll }) : header}
       </header>
-      <main className={'w-full min-w-full'}>{content}</main>
+      <main className="w-full min-w-full">{content}</main>
       <footer className="w-full py-[10px]">{footer}</footer>
     </div>
   )

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,1 +1,6 @@
 @import './tailwind.css';
+
+/* styles/globals.css */
+body {
+  overflow-y: scroll; /* 수직 스크롤바가 항상 나타나도록 설정 */
+}


### PR DESCRIPTION
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
홈 EXHIBITION 페이지 실제앱과 동일한 헤더 제작

- [x] 글로벌 CSS 
레이아웃 시프트 없애기 위해 아래 코드 글로벌 CSS 적용

body {
  overflow-y: scroll; /* 수직 스크롤바가 항상 나타나도록 설정 */
}